### PR TITLE
Update install commands in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Any third party verifier can view the state of the document submission process f
 
 
 ## Commands
-- Clone: `gh repo clone a16z/zk-documents-mono`
+- Clone: `gh repo clone a16z/zkdocs`
 - Install: `yarn install`
 - Check `./zkdocs-ui` + `./zkdocs-backend` for workspace specific commands.
 


### PR DESCRIPTION
Updated the repo name in the readme. A quick search revealed this is the only place this name was used in the docs.