### PR TITLE
Fixed script breaking is spaces in paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 artifacts
 typechain-types
 circuit_cache
-
+.idea

--- a/zkdocs-backend/scripts/tasks.ts
+++ b/zkdocs-backend/scripts/tasks.ts
@@ -5,7 +5,7 @@ import { ZkDocGenerator } from "../generator/ZkDocGenerator";
 import { keccakJson } from "zkdocs-lib";
 
 const POT_PATH = path.join(__dirname, "..", "build", "pot16_final.ptau");
-const CACHE_DIR = path.join(__dirname, "..", "circuit_cache")
+const CACHE_DIR = path.join(__dirname, "..", "circuit_cache");
 
 export async function buildAndDeploySchema(args: any, hre: any) {
     await build(args.schema)


### PR DESCRIPTION
I escaped the path in every command using "" but we could have escaped the path string too. I chose to do it this way as escaping may have other side effects (may not) and because "" is clearer to most users I would think.

Additionally, I cleaned up the code as I went along converting `let` to `const` and general cleanup.